### PR TITLE
fix rename Spritesheet to SpriteSheet

### DIFF
--- a/examples/android/app/src/main/jni/Player.hpp
+++ b/examples/android/app/src/main/jni/Player.hpp
@@ -28,7 +28,7 @@ public:
 private:
     void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
-    ns::Spritesheet m_spritesheet;
+    ns::SpriteSheet m_spritesheet;
     bool m_double_jump = false;
     bool m_in_air = false;
     bool m_must_land = false;


### PR DESCRIPTION
The SpriteSheet class name was changed from `Spritesheet` to `SpriteSheet` in the commit 3fc5340